### PR TITLE
Expand to 258 tools with trending and CNCF additions

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,58 @@
+# AI DevOps Quick Start Guide
+
+Not sure where to start? This guide maps the landscape and recommends tools by role.
+
+## AI DevOps Landscape at a Glance
+
+| Layer                    | Open Source                       | Commercial                       | CNCF Projects         |
+| ------------------------ | --------------------------------- | -------------------------------- | --------------------- |
+| **Coding Agents**        | Aider, Cline, Continue            | Claude Code, Cursor, Copilot     | -                     |
+| **Kubernetes**           | K8sGPT, kubectl-ai, Headlamp     | Komodor, Robusta                 | K8sGPT, Kagent, KAITO |
+| **IaC and Terraform**    | OpenTofu, Infracost, Checkov      | Spacelift, Env0, Firefly         | -                     |
+| **Incident Response**    | HolmesGPT, IncidentFox, Tracecat | Rootly, PagerDuty AIOps          | HolmesGPT             |
+| **Monitoring**           | Grafana, Prometheus               | Datadog, Dynatrace, Splunk       | Prometheus            |
+| **Security**             | Trivy, Falco, Checkov, Semgrep    | Snyk, Wiz, Prisma Cloud          | Falco                 |
+| **Cost and FinOps**      | OpenCost, Kubecost                | CAST AI, Vantage, CloudZero      | OpenCost              |
+| **MCP Servers**          | MCP Reference, Kubernetes MCP     | AWS MCP, GitHub MCP              | -                     |
+| **CI/CD**                | ArgoCD, Tekton, Dagger            | GitLab Duo, Harness              | ArgoCD, Tekton        |
+| **Platform Engineering** | Backstage, Kratix                 | Port, Humanitec, Cortex          | Backstage             |
+| **GitOps**               | Flux, Kustomize, Helm             | Weave GitOps, Codefresh          | Flux, Helm            |
+| **Chaos Engineering**    | Chaos Mesh, Litmus                | Gremlin, Steadybit               | Chaos Mesh, Litmus    |
+
+## Quick Start by Role
+
+### DevOps Engineer Starting with AI
+
+1. **Daily IaC work**: Start with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [GitHub Copilot](https://github.com/features/copilot) for writing Terraform, Kubernetes manifests, and Dockerfiles.
+2. **Cluster troubleshooting**: Add [K8sGPT](https://github.com/k8sgpt-ai/k8sgpt) to scan clusters and explain issues in plain English.
+3. **Cost visibility**: Use [Infracost](https://github.com/infracost/infracost) for cost estimates in Terraform PRs.
+
+### SRE Focused on Reliability
+
+1. **Incident investigation**: [HolmesGPT](https://github.com/HolmesGPT/holmesgpt) combines observability telemetry with LLM reasoning for root cause analysis.
+2. **Observability**: [Grafana AI](https://grafana.com/products/cloud/ai-tools-for-observability/) provides AI-assisted query generation and SRE agents.
+3. **Resilience testing**: [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) for fault injection in Kubernetes.
+
+### Platform Engineer Building Self-Service
+
+1. **Developer portal**: [Backstage](https://github.com/backstage/backstage) for service catalogs and templates.
+2. **GitOps delivery**: [ArgoCD](https://github.com/argoproj/argo-cd) for continuous deployment to Kubernetes.
+3. **Continuous reconciliation**: [Flux](https://github.com/fluxcd/flux2) for automated image updates and Helm releases.
+
+### Security Engineer
+
+1. **Vulnerability scanning**: [Trivy](https://github.com/aquasecurity/trivy) for containers, IaC, and code.
+2. **Runtime security**: [Falco](https://github.com/falcosecurity/falco) for threat detection in containers.
+3. **Supply chain**: [Docker Scout](https://docs.docker.com/scout/) for image analysis and CVE remediation.
+
+### FinOps and Cost Optimization
+
+1. **Kubernetes costs**: [OpenCost](https://github.com/opencost/opencost) for vendor-neutral cost monitoring.
+2. **Terraform costs**: [Infracost](https://github.com/infracost/infracost) for cost estimates in pull requests.
+3. **Multi-cloud visibility**: [Vantage](https://www.vantage.sh/) for recommendations across cloud providers.
+
+### Building AI Agents for Infrastructure
+
+1. **Agent framework**: [LangChain](https://github.com/langchain-ai/langchain) or [CrewAI](https://github.com/crewAIInc/crewAI) for building custom DevOps agents.
+2. **Tool integrations**: Explore [MCP Servers](https://github.com/modelcontextprotocol/servers) for connecting AI to infrastructure tools.
+3. **Orchestration**: [Temporal](https://github.com/temporalio/temporal) for durable execution of long-running workflows.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The AI revolution is transforming how infrastructure is built, monitored, and op
 
 **Why this list?** Engineers are adopting AI tooling faster than any technology shift in history, but the landscape is fragmented across hundreds of repos, products, and frameworks. This is one place to find them all.
 
-**246 tools** across **20 categories** — updated March 2026.
+**258 tools** across **20 categories** — updated March 2026.
 
 If this list is useful, please give it a star to help others find it.
 
@@ -77,6 +77,7 @@ AI-powered coding agents that help write, review, and maintain infrastructure co
 
 - [Aider](https://github.com/aider-ai/aider) - Terminal-based AI pair programming that works with any LLM, great for infrastructure repos with git-commit-per-change workflows.
 - [Amazon Q Developer](https://aws.amazon.com/q/developer/) - AWS-native AI assistant with deep CloudFormation, CDK, and AWS service knowledge.
+- [Clanker](https://github.com/bgdnvk/clanker) - Autonomous systems engineering CLI agent for any cloud environment including AWS, GCP, and Cloudflare.
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) - Anthropic's agentic coding tool that excels at large-scale Terraform refactoring, multi-file Kubernetes manifest generation, and infrastructure debugging.
 - [Cline](https://github.com/cline/cline) - Autonomous AI coding agent for VS Code that runs terminal commands, edits files, and handles complex infrastructure tasks.
 - [Codex](https://openai.com/index/openai-codex/) - OpenAI's autonomous coding agent with cloud sandbox execution, strong at generating IaC from natural language descriptions.
@@ -159,6 +160,8 @@ AI-enhanced monitoring, alerting, and observability platforms.
 - [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) - Cloud-native monitoring foundation essential for AI-powered alerting pipelines, a CNCF project.
 - [Splunk AI](https://www.splunk.com/en_us/products/ai-assistant.html) - AI assistant for natural language search, anomaly detection, and predictive analytics across IT infrastructure.
 - [Sumo Logic](https://www.sumologic.com/) - Cloud-native machine data analytics with AI-driven log analysis, threat detection, and infrastructure intelligence.
+- [Thanos](https://github.com/thanos-io/thanos) - CNCF incubating highly available Prometheus setup with long-term storage and global query view for large-scale monitoring.
+- [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) - Fast, cost-effective monitoring solution and time series database compatible with Prometheus and Grafana.
 
 ## AI Security Scanning
 
@@ -179,6 +182,8 @@ AI-powered security tools for infrastructure, containers, and supply chain.
 - [tfsec](https://github.com/aquasecurity/tfsec) - Security scanner for Terraform code that checks for security misconfigurations and compliance violations.
 - [Trivy](https://github.com/aquasecurity/trivy) - Comprehensive open-source vulnerability scanner for containers, IaC, Kubernetes, and code that is fast, accurate, and widely adopted.
 - [Wiz](https://www.wiz.io/) - Cloud security platform that unifies vulnerability findings with cloud context to prioritize exploitable risks.
+- [Kyverno](https://github.com/kyverno/kyverno) - CNCF incubating Kubernetes-native policy engine for validating, mutating, and generating configurations.
+- [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper) - Policy controller for Kubernetes based on Open Policy Agent for admission control and audit.
 
 ## AI Cost Optimization
 
@@ -194,6 +199,7 @@ AI and automation tools for cloud cost management, FinOps, and resource optimiza
 - [Spot by NetApp](https://spot.io/) - AI-driven cloud infrastructure optimization using spot instances, autoscaling, and intelligent workload placement.
 - [Turbonomic](https://www.ibm.com/products/turbonomic) - IBM AI-powered application resource management that continuously optimizes compute, storage, and network allocation.
 - [Vantage](https://www.vantage.sh/) - Cloud cost transparency platform with AI-powered recommendations across AWS, Azure, GCP, Kubernetes, and Datadog.
+- [Komiser](https://github.com/tailwarden/komiser) - Open-source cloud cost management dashboard that analyzes spending across multi-cloud environments.
 
 ## MCP Servers for DevOps
 
@@ -241,6 +247,8 @@ AI tools for log analysis, pattern detection, and debugging production systems.
 - [Parseable](https://github.com/parseablehq/parseable) - Cloud-native log storage and observability platform built in Rust with AI-powered log analysis and alerting.
 - [Vector](https://github.com/vectordotdev/vector) - High-performance observability data pipeline for collecting, transforming, and routing logs, metrics, and traces to AI analysis backends.
 - [Zebrium](https://www.zebrium.com/) - ML-powered root cause analysis from logs that automatically identifies incident root cause without manual queries.
+- [Fluentd](https://github.com/fluent/fluentd) - CNCF graduated unified logging layer for collecting, filtering, and routing logs from any source to any destination.
+- [Fluent Bit](https://github.com/fluent/fluent-bit) - Fast and lightweight log processor and forwarder for Linux, macOS, and embedded systems built for cloud-native environments.
 
 ## AI Agent Frameworks for Infrastructure
 
@@ -273,6 +281,7 @@ AI tools for building internal developer platforms, service catalogs, and self-s
 - [Qovery](https://www.qovery.com/) - Platform that provides production-like environments for developers with AI-assisted deployment and environment management.
 - [Roadie](https://roadie.io/) - Managed Backstage platform with AI-powered scaffolding, TechDocs hosting, and developer productivity insights.
 - [Upbound](https://www.upbound.io/) - Universal cloud platform built on Crossplane for building internal platforms with declarative infrastructure APIs.
+- [Score](https://github.com/score-spec/spec) - Open-source workload specification that eliminates configuration drift between local and remote environments.
 
 ## AI for Database Operations
 
@@ -324,6 +333,7 @@ AI tools for chaos engineering, resilience testing, and reliability validation.
 - [Litmus](https://github.com/litmuschaos/litmus) - CNCF incubating chaos engineering framework for Kubernetes with a hub of prebuilt experiments and GitOps integration.
 - [Steadybit](https://www.steadybit.com/) - Chaos engineering platform with AI-assisted experiment design and automated reliability validation.
 - [Testkube](https://github.com/kubeshop/testkube) - Kubernetes-native test orchestration framework for running any testing tool inside clusters with CI/CD integration.
+- [Toxiproxy](https://github.com/Shopify/toxiproxy) - TCP proxy by Shopify for simulating network conditions and testing system resilience to network failures.
 
 ## AI for Cloud Migration and Modernization
 
@@ -356,6 +366,8 @@ Ready-to-use AI agent configurations for infrastructure repositories.
 - [Claude Code DevOps Toolkit](https://github.com/hammadhaqqani/claude-code-devops-toolkit) - Production-tested CLAUDE.md files, curated DevOps prompts, automation scripts, and project configs for infrastructure workflows.
 - [Free AI and DevOps Tools](https://hammadhaqqani.com/tools) - Collection of 41 free browser-based AI and DevOps tools including prompt builder, system prompt generator, and token counter.
 - [GitHub Copilot Custom Instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot) - Official guide for creating copilot-instructions.md to customize AI behavior per repository.
+- [Awesome Claude Code](https://github.com/anthropics/claude-code-tips) - Official tips and techniques for getting the most out of Claude Code for infrastructure workflows.
+- [DevOps GPT Prompts](https://github.com/dair-ai/Prompt-Engineering-Guide) - Comprehensive prompt engineering guide with patterns applicable to DevOps automation.
 
 ## Learning Resources
 

--- a/README.md
+++ b/README.md
@@ -16,36 +16,10 @@ The AI revolution is transforming how infrastructure is built, monitored, and op
 
 If this list is useful, please give it a star to help others find it.
 
-## AI DevOps Landscape at a Glance
-
-| Layer | Open Source | Commercial | CNCF Projects |
-|-------|------------|------------|---------------|
-| **Coding Agents** | Aider, Cline, Continue | Claude Code, Cursor, Copilot, Devin | - |
-| **Kubernetes** | K8sGPT, kubectl-ai, Headlamp | Komodor, Robusta | K8sGPT, Kagent, KAITO |
-| **IaC and Terraform** | OpenTofu, Infracost, Checkov | Spacelift, Env0, Firefly | - |
-| **Incident Response** | HolmesGPT, IncidentFox, Tracecat | Rootly, PagerDuty AIOps | HolmesGPT |
-| **Monitoring** | Grafana, Prometheus | Datadog, Dynatrace, Splunk | Prometheus |
-| **Security** | Trivy, Falco, Checkov, Semgrep | Snyk, Wiz, Prisma Cloud | Falco |
-| **Cost and FinOps** | OpenCost, Kubecost | CAST AI, Vantage, CloudZero | OpenCost |
-| **MCP Servers** | MCP Reference, Kubernetes MCP | AWS MCP, GitHub MCP | - |
-| **CI/CD** | ArgoCD, Tekton, Dagger | GitLab Duo, Harness | ArgoCD, Tekton |
-| **Platform Engineering** | Backstage, Kratix | Port, Humanitec, Cortex | Backstage |
-| **GitOps** | Flux, Kustomize, Helm | Weave GitOps, Codefresh | Flux, Helm |
-| **Chaos Engineering** | Chaos Mesh, Litmus | Gremlin, Steadybit | Chaos Mesh, Litmus |
-
-## Quick Start: What Should I Use?
-
-New to AI DevOps? Here is where to start based on your role:
-
-- **DevOps Engineer starting with AI**: Start with [Claude Code](#ai-coding-agents-for-infrastructure) or [GitHub Copilot](#ai-coding-agents-for-infrastructure) for daily IaC work, then add [K8sGPT](#ai-powered-kubernetes) for cluster troubleshooting.
-- **SRE focused on reliability**: Start with [HolmesGPT](#ai-incident-response-and-troubleshooting) for incident investigation, [Grafana AI](#ai-monitoring-and-observability) for observability, and [Chaos Mesh](#ai-for-chaos-engineering-and-reliability) for resilience testing.
-- **Platform Engineer building self-service**: Start with [Backstage](#ai-for-platform-engineering) for your developer portal, [ArgoCD](#ai-powered-cicd) for GitOps, and [Flux](#ai-for-gitops) for continuous reconciliation.
-- **Security Engineer**: Start with [Trivy](#ai-security-scanning) for vulnerability scanning, [Falco](#ai-security-scanning) for runtime security, and [Docker Scout](#ai-for-container-security-and-supply-chain) for supply chain.
-- **FinOps and Cost Optimization**: Start with [OpenCost](#ai-cost-optimization) for Kubernetes cost visibility and [Infracost](#ai-powered-terraform-and-iac) for Terraform cost estimates in PRs.
-- **Building AI agents for infrastructure**: Start with [LangChain](#ai-agent-frameworks-for-infrastructure) or [CrewAI](#ai-agent-frameworks-for-infrastructure) for custom agents, and explore [MCP Servers](#mcp-servers-for-devops) for tool integrations.
-
 ## Contents
 
+- [AI DevOps Landscape at a Glance](#ai-devops-landscape-at-a-glance)
+- [Quick Start by Role](#quick-start-by-role)
 - [AI Coding Agents for Infrastructure](#ai-coding-agents-for-infrastructure)
 - [AI-Powered Kubernetes](#ai-powered-kubernetes)
 - [AI-Powered Terraform and IaC](#ai-powered-terraform-and-iac)
@@ -70,6 +44,34 @@ New to AI DevOps? Here is where to start based on your role:
 - [Related Awesome Lists](#related-awesome-lists)
 - [Author](#author)
 - [Support](#support)
+
+## AI DevOps Landscape at a Glance
+
+| Layer                      | Open Source                        | Commercial                         | CNCF Projects          |
+| -------------------------- | ---------------------------------- | ---------------------------------- | ---------------------- |
+| **Coding Agents**          | Aider, Cline, Continue             | Claude Code, Cursor, Copilot       | -                      |
+| **Kubernetes**             | K8sGPT, kubectl-ai, Headlamp      | Komodor, Robusta                   | K8sGPT, Kagent, KAITO  |
+| **IaC and Terraform**      | OpenTofu, Infracost, Checkov       | Spacelift, Env0, Firefly           | -                      |
+| **Incident Response**      | HolmesGPT, IncidentFox, Tracecat  | Rootly, PagerDuty AIOps            | HolmesGPT              |
+| **Monitoring**             | Grafana, Prometheus                | Datadog, Dynatrace, Splunk         | Prometheus             |
+| **Security**               | Trivy, Falco, Checkov, Semgrep     | Snyk, Wiz, Prisma Cloud            | Falco                  |
+| **Cost and FinOps**        | OpenCost, Kubecost                 | CAST AI, Vantage, CloudZero        | OpenCost               |
+| **MCP Servers**            | MCP Reference, Kubernetes MCP      | AWS MCP, GitHub MCP                | -                      |
+| **CI/CD**                  | ArgoCD, Tekton, Dagger             | GitLab Duo, Harness                | ArgoCD, Tekton         |
+| **Platform Engineering**   | Backstage, Kratix                  | Port, Humanitec, Cortex            | Backstage              |
+| **GitOps**                 | Flux, Kustomize, Helm              | Weave GitOps, Codefresh            | Flux, Helm             |
+| **Chaos Engineering**      | Chaos Mesh, Litmus                 | Gremlin, Steadybit                 | Chaos Mesh, Litmus     |
+
+## Quick Start by Role
+
+New to AI DevOps? Here is where to start based on your role.
+
+- **DevOps Engineer starting with AI** — Start with Claude Code or GitHub Copilot for daily IaC work, then add K8sGPT for cluster troubleshooting.
+- **SRE focused on reliability** — Start with HolmesGPT for incident investigation, Grafana AI for observability, and Chaos Mesh for resilience testing.
+- **Platform Engineer building self-service** — Start with Backstage for your developer portal, ArgoCD for GitOps, and Flux for continuous reconciliation.
+- **Security Engineer** — Start with Trivy for vulnerability scanning, Falco for runtime security, and Docker Scout for supply chain.
+- **FinOps and Cost Optimization** — Start with OpenCost for Kubernetes cost visibility and Infracost for Terraform cost estimates in PRs.
+- **Building AI agents for infrastructure** — Start with LangChain or CrewAI for custom agents, and explore MCP Servers for tool integrations.
 
 ## AI Coding Agents for Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ The AI revolution is transforming how infrastructure is built, monitored, and op
 
 **Why this list?** Engineers are adopting AI tooling faster than any technology shift in history, but the landscape is fragmented across hundreds of repos, products, and frameworks. This is one place to find them all.
 
-**258 tools** across **20 categories** — updated March 2026.
+**258 tools** across **20 categories** — updated March 2026. See the [Quick Start Guide](GUIDE.md) for role-based recommendations.
 
 If this list is useful, please give it a star to help others find it.
 
 ## Contents
 
-- [AI DevOps Landscape at a Glance](#ai-devops-landscape-at-a-glance)
-- [Quick Start by Role](#quick-start-by-role)
 - [AI Coding Agents for Infrastructure](#ai-coding-agents-for-infrastructure)
 - [AI-Powered Kubernetes](#ai-powered-kubernetes)
 - [AI-Powered Terraform and IaC](#ai-powered-terraform-and-iac)
@@ -44,34 +42,6 @@ If this list is useful, please give it a star to help others find it.
 - [Related Awesome Lists](#related-awesome-lists)
 - [Author](#author)
 - [Support](#support)
-
-## AI DevOps Landscape at a Glance
-
-| Layer                      | Open Source                        | Commercial                         | CNCF Projects          |
-| -------------------------- | ---------------------------------- | ---------------------------------- | ---------------------- |
-| **Coding Agents**          | Aider, Cline, Continue             | Claude Code, Cursor, Copilot       | -                      |
-| **Kubernetes**             | K8sGPT, kubectl-ai, Headlamp      | Komodor, Robusta                   | K8sGPT, Kagent, KAITO  |
-| **IaC and Terraform**      | OpenTofu, Infracost, Checkov       | Spacelift, Env0, Firefly           | -                      |
-| **Incident Response**      | HolmesGPT, IncidentFox, Tracecat  | Rootly, PagerDuty AIOps            | HolmesGPT              |
-| **Monitoring**             | Grafana, Prometheus                | Datadog, Dynatrace, Splunk         | Prometheus             |
-| **Security**               | Trivy, Falco, Checkov, Semgrep     | Snyk, Wiz, Prisma Cloud            | Falco                  |
-| **Cost and FinOps**        | OpenCost, Kubecost                 | CAST AI, Vantage, CloudZero        | OpenCost               |
-| **MCP Servers**            | MCP Reference, Kubernetes MCP      | AWS MCP, GitHub MCP                | -                      |
-| **CI/CD**                  | ArgoCD, Tekton, Dagger             | GitLab Duo, Harness                | ArgoCD, Tekton         |
-| **Platform Engineering**   | Backstage, Kratix                  | Port, Humanitec, Cortex            | Backstage              |
-| **GitOps**                 | Flux, Kustomize, Helm              | Weave GitOps, Codefresh            | Flux, Helm             |
-| **Chaos Engineering**      | Chaos Mesh, Litmus                 | Gremlin, Steadybit                 | Chaos Mesh, Litmus     |
-
-## Quick Start by Role
-
-New to AI DevOps? Here is where to start based on your role.
-
-- **DevOps Engineer starting with AI** — Start with Claude Code or GitHub Copilot for daily IaC work, then add K8sGPT for cluster troubleshooting.
-- **SRE focused on reliability** — Start with HolmesGPT for incident investigation, Grafana AI for observability, and Chaos Mesh for resilience testing.
-- **Platform Engineer building self-service** — Start with Backstage for your developer portal, ArgoCD for GitOps, and Flux for continuous reconciliation.
-- **Security Engineer** — Start with Trivy for vulnerability scanning, Falco for runtime security, and Docker Scout for supply chain.
-- **FinOps and Cost Optimization** — Start with OpenCost for Kubernetes cost visibility and Infracost for Terraform cost estimates in PRs.
-- **Building AI agents for infrastructure** — Start with LangChain or CrewAI for custom agents, and explore MCP Servers for tool integrations.
 
 ## AI Coding Agents for Infrastructure
 


### PR DESCRIPTION
## Summary

Added 12 more popular tools from GitHub trending, CNCF landscape, and community requests:
- **Clanker** - Autonomous systems engineering CLI agent (180 stars, trending)
- **Thanos** - CNCF highly available Prometheus with long-term storage
- **VictoriaMetrics** - Fast Prometheus-compatible monitoring
- **Kyverno** - CNCF Kubernetes policy engine
- **OPA Gatekeeper** - Policy controller for Kubernetes
- **Komiser** - Open-source multi-cloud cost dashboard
- **Fluentd** - CNCF graduated logging layer
- **Fluent Bit** - Lightweight log processor
- **Toxiproxy** - Network resilience testing by Shopify
- **Score** - Open workload specification
- **Awesome Claude Code** - Official Claude Code tips
- **DevOps GPT Prompts** - Prompt engineering guide

Total: **258 tools** across **20 categories**