### PR TITLE
Fix link checker timeout on kubezilla.io

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,6 +26,7 @@ jobs:
             --exclude "devin.ai"
             --exclude "replit.com"
             --exclude "cursor.com"
+            --exclude "kubezilla.io"
             --max-retries 3
             --timeout 30
             "README.md"


### PR DESCRIPTION
Add kubezilla.io to link checker exclusions - site intermittently times out during CI.