### PR TITLE
Fix link checker: accept 503 for transient GitHub badge errors

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,7 +17,7 @@ jobs:
           args: >
             --verbose
             --no-progress
-            --accept 200,204,301,302,403,429
+            --accept 200,204,301,302,403,429,503
             --exclude-path CODE_OF_CONDUCT.md
             --exclude "linkedin.com"
             --exclude "x.com"


### PR DESCRIPTION
GitHub badge SVGs occasionally return 503 during Pages deploys. Accept 503 to prevent false positives.