### PR TITLE
Add toprank — open-source SEO & Google Ads plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ AI-powered coding agents that help write, review, and maintain infrastructure co
 - [Goose](https://github.com/block/goose) - Open-source autonomous AI agent by Block written in Rust that installs, executes, edits, and tests with any LLM via MCP under Apache 2.0.
 - [Kiro](https://kiro.dev/) - AWS spec-driven agentic IDE that uses structured requirements, design docs, and agent hooks to produce reproducible infrastructure code.
 - [Zed AI](https://zed.dev/) - High-performance editor with built-in AI assistant, inline generation, and terminal integration for infrastructure workflows.
+- [toprank](https://github.com/nowork-studio/toprank) - Open-source Claude Code plugin (MIT) providing 9 SEO and Google Ads skills — connects Google Search Console, PageSpeed Insights, and Google Ads API for automated audits, keyword research, and content optimization directly from Claude Code.
+
 
 ## AI-Powered Kubernetes
 


### PR DESCRIPTION
## Summary

Adds [toprank](https://github.com/nowork-studio/toprank) to the listing — an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills.

**What it does:**
- Connects Google Search Console, PageSpeed Insights, and the Google Ads API
- Ships fixes directly from Claude Code: meta tag rewrites, JSON-LD schema markup generation, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost

**Details:**
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 200+ stars, actively maintained