### PR TITLE
Fix broken AWS Terraform MCP Server link to pass Link Check CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ AI tools specifically designed for Kubernetes cluster management, troubleshootin
 Tools that bring AI capabilities to Infrastructure as Code workflows.
 
 - [Atmos](https://github.com/cloudposse/atmos) - Universal tool for DevOps workflows that provides a framework for managing Terraform configurations at scale with AI-assisted component discovery.
-- [AWS Terraform MCP Server](https://awslabs.github.io/mcp/servers/terraform-mcp-server) - AWS MCP server with Terraform best practices, Checkov security scanning, and AWS provider documentation search.
+- [AWS Terraform MCP Server](https://pypi.org/project/awslabs.terraform-mcp-server/) - AWS Labs MCP server with Terraform best practices, Checkov security scanning, and AWS provider documentation search.
 - [Brainboard](https://www.brainboard.co/) - Visual Terraform designer with AI-powered architecture generation from cloud diagrams.
 - [Env0](https://www.env0.com/) - Self-service infrastructure platform with AI-assisted policy enforcement, cost estimation, and drift detection for Terraform.
 - [Firefly](https://www.firefly.ai/) - Cloud asset management that uses AI to detect drift, generate Terraform from existing resources, and manage IaC coverage gaps.


### PR DESCRIPTION
## Summary

The Link Check workflow was failing on main because `https://awslabs.github.io/mcp/servers/terraform-mcp-server` returned 404. AWS deprecated this server in favor of HashiCorp's official Terraform MCP Server (which is already listed separately in the repo).

Updated the URL to point to the PyPI package page which remains live.

## Verification

Ran lychee locally with the same CI config:

```
🔍 446 Total | ✅ 392 OK | 🚫 0 Errors | 👻 13 Excluded | 🔀 41 Redirects
```

Down from 1 error to 0.

## Test plan

- [x] Awesome Lint passes locally
- [x] Link Check passes locally (0 errors)
- [x] Target URL returns HTTP 200

https://claude.ai/code/session_018ACf3XFUK6uUR6rPgzK2Q4