### PR TITLE
Fix Link Check CI by excluding resourcely.io and tryparity.com

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -27,6 +27,8 @@ jobs:
             --exclude "replit.com"
             --exclude "cursor.com"
             --exclude "kubezilla.io"
+            --exclude "resourcely.io"
+            --exclude "tryparity.com"
             --max-retries 3
             --timeout 30
             "README.md"


### PR DESCRIPTION
## Summary

Fixes the failing Link Check workflow on main caused by PR #20.

Both URLs were verified working with a browser User-Agent but get blocked by bot detection when lychee fetches them in CI:

- `https://www.resourcely.io/` — Network error: `received fatal alert: InternalError` (Cloudflare/TLS-level blocking)
- `https://www.tryparity.com/` — Timeout

Adds both to the existing `--exclude` list alongside `cursor.com`, `devin.ai`, `replit.com`, `kubezilla.io`, and `shoreline.io` which are excluded for the same reason.

## Test plan

- [ ] Link Check workflow passes on this PR or in dispatch run after merge
- [ ] No README content changes (the entries themselves stay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)