### PR TITLE
Add click-to-mcp: auto-wrap any CLI as MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ Model Context Protocol servers that give AI assistants like Claude, ChatGPT, and
 - [Atlassian MCP Server](https://www.npmjs.com/package/@anthropic/mcp-atlassian) - MCP server for Jira and Confluence integration enabling AI agents to query issues, create tickets, and search documentation.
 - [AWS MCP Servers](https://awslabs.github.io/mcp/) - Official AWS MCP server suite covering Terraform, CDK, CloudFormation, Lambda, S3, CloudWatch, ECS, and more.
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Comprehensive curated list of all MCP servers across every category.
-- [Cloudflare MCP Server](https://github.com/cloudflare/mcp-server-cloudflare) - Official Cloudflare MCP server for managing Workers, KV, R2, and DNS from AI agents.
+- [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) - Auto-wrap any Click or typer CLI as an MCP server without writing server code, enabling AI agents to call existing DevOps CLI tools instantly.
+- [Cloudflare MCP Server]
 - [Datadog MCP Server](https://github.com/datadog-labs/mcp-server) - MCP server for querying Datadog metrics, monitors, dashboards, and logs from AI agents.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker-maintained MCP server for container management, image operations, and Docker Compose workflows.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official GitHub MCP server for repos, issues, PRs, Actions, and code search from AI agents.


### PR DESCRIPTION
## click-to-mcp — Auto-wrap CLIs as MCP Servers

Adds [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the **MCP Servers for DevOps** section.

### What it does
click-to-mcp automatically wraps any Click or typer CLI into a fully functional MCP server — zero server code required. AI agents (Claude Code, Codex, Cursor) can call existing DevOps CLI tools instantly.

### Why it fits here
- Gives AI agents instant access to any existing CLI DevOps tool
- Part of the Revenue Holdings ecosystem (api-contract-guardian, deploydiff, json2sql, configdrift all work as MCP servers via click-to-mcp)
- No rewrite required — just `pip install click-to-mcp` and configure

### Checklist
- [x] Alphabetical order maintained
- [x] Follows existing format (name, link, description)
- [x] Description explains what it does and why it matters for DevOps