### PR TITLE
feat: add TWZRD Agent Intel MCP server to MCP Servers for DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Model Context Protocol servers that give AI assistants like Claude, ChatGPT, and
 - [Temporal MCP Server](https://github.com/alisaitteke/temporal-mcp) - MCP server for running, querying, and signaling Temporal workflows from AI assistants for durable execution use cases.
 - [Istio MCP Server](https://github.com/krutsko/istio-mcp-server) - MCP server providing read-only access to Istio Virtual Services, Destination Rules, Gateways, and Envoy configs for AI-driven service mesh diagnosis.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and preflight checks for AI agents on Solana before executing paid runbooks or remediation API calls via x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 ## AI-Powered CI/CD
 
 AI tools that enhance continuous integration and delivery pipelines.


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP Servers for DevOps** section.

## Why it fits

DevOps and SRE teams are adopting AI agents for incident response, runbook execution, and automated remediation. TWZRD Agent Intel lets you verify an AI agent's wallet identity before allowing it to call paid x402-protected APIs (e.g., remediation runbooks, cloud cost APIs, alerting endpoints). This closes the "who is this agent?" gap in multi-agent DevOps workflows.

**Tools**: `score_agent` (trust score), `preflight_check` (pre-action identity check) — both free; `get_trust_receipt` (signed receipt, paid via x402 micropayment)

## Entry added

```markdown
- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and preflight checks for AI agents on Solana before executing paid runbooks or remediation API calls via x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
```

## Checklist
- [x] Link goes to a live public URL (not a private repo)
- [x] Description is concise and relevant to DevOps/SRE use cases
- [x] Entry added at end of MCP Servers for DevOps section