### PR TITLE
Add Aient AI to AI Incident Response and Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ AI systems that detect, investigate, and remediate production incidents.
 - [Mezmo Agentic SRE](https://www.mezmo.com/platform/agentic-sre) - AI agent that automates incident triage, root cause analysis, and remediation across logs, metrics, and traces using context engineering.
 - [TierZero AI](https://tierzero.ai/) - AI production agent that investigates incidents, triages alerts, fixes CI/CD failures, and executes remediation across the stack.
 - [Superlog](https://github.com/superloglabs/superlog) - Open-source AI observability tool that groups errors into incidents, investigates with full context, and posts a single mergeable fix PR in Slack.
+- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE that groups errors into problems, investigates root cause, and opens a GitHub pull request with a fix, then monitors telemetry to confirm the problem stops recurring.
 
 ## AI Monitoring and Observability
 


### PR DESCRIPTION
## What

Adds one entry — **Aient AI** — to the **AI Incident Response and Troubleshooting** section.

```markdown
- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE that groups errors into problems, investigates root cause, and opens a GitHub pull request with a fix, then monitors telemetry to confirm the problem stops recurring.
```

## Why it fits

Aient AI is an OpenTelemetry-native AI SRE / auto-remediation platform. It ingests logs, metrics, and traces (OTLP), groups errors into "problems," runs an AI agent that investigates root cause and **opens a GitHub pull request** with a fix, then watches production telemetry to check the problem stops recurring. The pull request is the human approval gate — it does not merge or deploy to production on its own. This sits alongside existing entries in the section such as IncidentFox, Superlog, and Middleware OpsAI.

- Homepage: https://aient.ai (returns 200)
- Docs: https://docs.aient.ai
- Integrations: GitHub, Slack, Linear, Vercel, AWS CloudWatch/Firehose; hosted OAuth-gated MCP server.
- Status: commercial, early-access, closed-source.

## Disclosure

This is a **vendor self-submission** — I'm affiliated with Aient AI (Triple Alpha AB). Kept the description to one factual sentence with no superlatives, added under the most relevant category, placed to match the section's existing append order, no duplicate link. The two pre-existing `Postgres` awesome-lint warnings are unrelated to this change (lines 51 and 444, untouched).