### PR TITLE
Add Chronicle to AI incident management tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ AI systems that detect, investigate, and remediate production incidents.
 
 - [BigPanda](https://www.bigpanda.io/) - AIOps platform for event correlation, automated root cause analysis, and intelligent incident management across hybrid environments.
 - [Blameless](https://www.blameless.com/) - SRE platform with AI-powered incident management, automated retrospectives, and reliability insights across distributed systems.
+- [Chronicle](https://github.com/shlokkokk/Chronicle) - Deduplicates alerts by signature, retrieves matching past incident resolutions from vector memory, and auto-escalates SLA breaches.
 - [FireHydrant](https://firehydrant.com/) - Incident management platform with AI-powered retrospective generation, automated status pages, and runbook execution.
 - [GitHub Agentic Workflows](https://github.github.io/gh-aw/) - Run AI agents in GitHub Actions for automated issue triage, CI failure analysis, and PR review.
 - [HolmesGPT](https://github.com/HolmesGPT/holmesgpt) - Agentic AI troubleshooting for Kubernetes and cloud-native environments, a CNCF Sandbox project combining observability telemetry with LLM reasoning.


### PR DESCRIPTION
## What tool/resource are you adding?

**Name:** Chronicle
**URL:**  https://github.com/shlokkokk/Chronicle
**Category:**  AI Incident Response and Troubleshooting

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] The tool is relevant to DevOps, SRE, or Platform Engineering with an AI/ML component
- [x] The tool is not already listed
- [x] I have added it in the correct category in the proper format
- [x] The description is one sentence and under 120 characters
- [x] I have included the appropriate tags (`open-source`, `commercial`, etc.)
- [x] For GitHub-hosted projects, I have included a star badge
- [x] The link works and points to the correct resource

## Why does this tool belong on the list?

Chronicle is an AI-native incident response platform that deduplicates alerts by signature, retrieves matching past resolutions from a dual-layer vector memory (Mem0 + pgvector), and auto-escalates SLA breaches across severities — directly fits the AI Incident Response category alongside tools like Cleric and Resolve AI.
