### PR TITLE
Add emisar to MCP Servers for DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Model Context Protocol servers that give AI assistants like Claude, ChatGPT, and
 - [Cloudflare MCP Server](https://github.com/cloudflare/mcp-server-cloudflare) - Official Cloudflare MCP server for managing Workers, KV, R2, and DNS from AI agents.
 - [Datadog MCP Server](https://github.com/datadog-labs/mcp-server) - MCP server for querying Datadog metrics, monitors, dashboards, and logs from AI agents.
 - [Docker MCP Gateway](https://github.com/docker/mcp-gateway) - Docker-maintained MCP server for container management, image operations, and Docker Compose workflows.
+- [emisar](https://github.com/AndrewDryga/emisar) - Runs defined infrastructure actions for AI agents with policy and approval gates, host validation, and an audit trail.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - Official GitHub MCP server for repos, issues, PRs, Actions, and code search from AI agents.
 - [Grafana MCP Server](https://github.com/grafana/mcp-grafana) - Official Grafana MCP server for querying dashboards, datasources, and alerts from AI agents.
 - [Kubernetes MCP Server](https://github.com/Flux159/mcp-server-kubernetes) - MCP server for kubectl operations, pod management, and cluster introspection.


### PR DESCRIPTION
## What tool/resource are you adding?

**Name:** emisar
**URL:** https://github.com/AndrewDryga/emisar
**Category:** MCP Servers for DevOps

## Checklist

- [x] I have read the contributing guidelines
- [x] The tool is relevant to DevOps, SRE, or Platform Engineering with an AI component
- [x] The tool is not already listed
- [x] I have added it in the correct category and existing section format
- [x] The description is one sentence, 118 characters, and ends with a period
- [x] The link works and points to the canonical repository

The existing MCP section does not use inline tags or star badges, so this entry follows the section's current one-link format.

## Why does this tool belong on the list?

emisar gives MCP-capable agents a defined set of infrastructure actions instead of arbitrary shell access. Access and policy are checked before dispatch, actions can wait for approval, and the runner validates them again on the host.

## Verification

- `npx awesome-lint` (passes with two pre-existing spelling warnings)
- `git diff --check`
- confirmed the project link is reachable
