### PR TITLE
Add kprompt to AI-Powered Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ AI tools specifically designed for Kubernetes cluster management, troubleshootin
 - [KServe](https://github.com/kserve/kserve) - Standardized distributed AI inference platform for Kubernetes supporting multi-framework model serving with autoscaling and canary rollouts.
 - [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations, MCP server for natural-language cluster management, and real-time observability across edge and cloud clusters. CNCF Sandbox project.
 - [Komodor](https://komodor.com/) - Kubernetes troubleshooting platform with AI-driven root cause analysis, change tracking, and automated remediation workflows.
+- [kprompt](https://github.com/kprompt/kprompt) - AI Kubernetes CLI that compiles natural language into reviewable plans with risk and blast-radius checks before approved changes are applied.
 - [kubectl-ai](https://github.com/GoogleCloudPlatform/kubectl-ai) - Google Cloud kubectl plugin that uses LLMs to generate and apply Kubernetes manifests from natural language.
 - [Kubernetes ChatGPT Bot](https://github.com/robusta-dev/kubernetes-chatgpt-bot) - ChatGPT integration for Kubernetes troubleshooting via Slack notifications.
 - [Kubeflow](https://github.com/kubeflow/kubeflow) - CNCF incubating ML platform for Kubernetes with distributed training, model serving, pipelines, and notebook environments for AI workloads.


### PR DESCRIPTION
## Summary
- Add kprompt to the AI-Powered Kubernetes category.
- Describe its reviewable plan, risk, blast-radius, and approval-gated apply workflow.

## Validation
- [x] Confirmed the project is not already listed.
- [x] Added one entry in the relevant category.
- [x] Used the canonical repository URL.
- [x] Ran `npx --yes awesome-lint` successfully (two pre-existing PostgreSQL spelling warnings remain elsewhere in the README).

Made with [Cursor](https://cursor.com)