### PR TITLE
Add NudgeBee to AI Incident Response and Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ AI systems that detect, investigate, and remediate production incidents.
 - [incident.io](https://incident.io/) - Incident management platform with AI-powered summaries, automated workflows, and native Slack integration for end-to-end response.
 - [IncidentFox](https://github.com/incidentfox/incidentfox) - Open-source AI SRE platform for automated incident investigation, hypothesis formation, and fix suggestions with Slack and PagerDuty integration.
 - [Moogsoft](https://www.moogsoft.com/) - AIOps platform with AI-driven noise reduction, correlation, and situation awareness for reducing alert fatigue.
+- [NudgeBee](https://github.com/nudgebee/nudgebee) - Self-hosted agentic platform that investigates incidents to a cited root cause across AWS, Azure, GCP, and Kubernetes and executes approval-gated remediation runbooks.
 - [Opsgenie](https://www.atlassian.com/software/opsgenie) - Incident management with AI-powered alert routing, on-call scheduling, and intelligent escalation by Atlassian.
 - [PagerDuty AIOps](https://www.pagerduty.com/platform/aiops/) - AI event correlation, noise reduction, and intelligent routing that reduces alert fatigue with ML-based grouping.
 - [Keep](https://github.com/keephq/keep) - Open-source AIOps platform that correlates, deduplicates, and routes alerts from any monitoring tool with AI-powered noise reduction and workflow automation.


### PR DESCRIPTION
Disclosure: I work on NudgeBee.

Adding NudgeBee to AI Incident Response and Troubleshooting.

NudgeBee is a self-hosted platform whose agents investigate incidents to an evidence-cited root cause across AWS, Azure, GCP and Kubernetes, then execute remediation runbooks. Every write operation is classified and gated behind human approval, so the agent cannot change infrastructure on its own.

Checked against the contributing guidelines:
- Single category only, no duplicate link elsewhere in the README.
- Alphabetical position within the category (between Moogsoft and Opsgenie).
- Description is one line ending with a period, no backtick tags or badges.
- "Kubernetes" spelled in full.

Repo: https://github.com/nudgebee/nudgebee (380 stars, actively developed).
