### PR TITLE
Add Darkmoon (autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ AI-powered security tools for infrastructure, containers, and supply chain.
 - [SonarQube](https://www.sonarsource.com/products/sonarqube/) - Code quality and security analysis platform with AI-powered code smell detection and vulnerability identification.
 - [Terraform Sentinel](https://www.hashicorp.com/sentinel) - Policy-as-code framework by HashiCorp that enforces fine-grained, logic-based policies on Terraform infrastructure changes.
 - [tfsec](https://github.com/aquasecurity/tfsec) - Security scanner for Terraform code that checks for security misconfigurations and compliance violations.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes.
 - [Trivy](https://github.com/aquasecurity/trivy) - Comprehensive open-source vulnerability scanner for containers, IaC, Kubernetes, and code that is fast, accurate, and widely adopted.
 - [Wiz](https://www.wiz.io/) - Cloud security platform that unifies vulnerability findings with cloud context to prioritize exploitable risks.
 - [Kyverno](https://github.com/kyverno/kyverno) - CNCF incubating Kubernetes-native policy engine for validating, mutating, and generating configurations.


### PR DESCRIPTION
Thank you for maintaining this list. We would like to propose adding Darkmoon to the AI Security Scanning section. Darkmoon is an open source (GPL 3.0) autonomous AI penetration testing platform that covers web, API, Active Directory and Kubernetes, and it runs fully self hosted. It sits naturally alongside the other security and auditing tools already listed here. Repository: https://github.com/ASCIT31/Dark-Moon