### PR TITLE
Add Adios MCP Server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ AI and automation tools for cloud cost management, FinOps, and resource optimiza
 
 Model Context Protocol servers that give AI assistants like Claude, ChatGPT, and Cursor access to DevOps tools and infrastructure.
 
+- [Adios MCP Server](https://github.com/adiosdotdev/mcp) - Official MCP server for managing Adios workspaces, previews, builds, logs, services, and production deployments from AI.
 - [Atlassian MCP Server](https://www.npmjs.com/package/@anthropic/mcp-atlassian) - MCP server for Jira and Confluence integration enabling AI agents to query issues, create tickets, and search documentation.
 - [AWS MCP Servers](https://awslabs.github.io/mcp/) - Official AWS MCP server suite covering Terraform, CDK, CloudFormation, Lambda, S3, CloudWatch, ECS, and more.
 - [Awesome MCP Servers](https://github.com/punkpeye/awesome-mcp-servers) - Comprehensive curated list of all MCP servers across every category.


### PR DESCRIPTION
Added Adios MCP Server to the list of available MCP servers.

## What tool/resource are you adding?

**Name:** Adios MCP Server  
**URL:** https://github.com/adiosdotdev/mcp  
**Category:** MCP Servers for DevOps

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] The tool is relevant to DevOps, SRE, or Platform Engineering with an AI/ML component
- [x] The tool is not already listed
- [x] I have added it in the correct category in alphabetical order and in the proper format
- [x] The description is one sentence, 108 characters, and ends with a period
- [x] The link works and points to the canonical repository

The existing MCP section does not use inline tags or star badges, so this entry follows the section's current one-link format.

## Why does this tool belong on the list?

Adios MCP Server connects MCP-compatible AI assistants to application development and DevOps workflows, including source management, previews, builds, logs, managed services, and production deployments.

It gives DevOps and platform engineers an authenticated interface for inspecting applications, diagnosing build or runtime failures, managing services, and deploying changes without switching between multiple dashboards and command-line tools.

## Disclosure

I am the founder of Adios.dev and maintain this integration.