### PR TITLE
Add agent-qa to AI-powered CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Model Context Protocol servers that give AI assistants like Claude, ChatGPT, and
 
 AI tools that enhance continuous integration and delivery pipelines.
 
+- [agent-qa](https://github.com/vostride/agent-qa) - Self-improving QA agent for natural-language web and mobile tests with memory, self-healing, and CLI workflows.
 - [ArgoCD](https://github.com/argoproj/argo-cd) - CNCF GitOps continuous delivery for Kubernetes that serves as the foundation for AI-driven deployment workflows.
 - [Buildkite](https://buildkite.com/) - CI/CD platform with AI-powered test analytics, flaky test detection, and intelligent pipeline optimization for infrastructure builds.
 - [CircleCI](https://circleci.com/) - Cloud CI/CD platform with AI-powered test splitting, flaky test detection, and pipeline optimization insights.


### PR DESCRIPTION
## What tool/resource are you adding?

**Name:** agent-qa
**URL:** https://github.com/vostride/agent-qa
**Category:** AI-Powered CI/CD

## Checklist

- [x] I have read the contributing guidelines
- [x] The tool is relevant to DevOps, SRE, or Platform Engineering with an AI/ML component
- [x] The tool is not already listed
- [x] I have added it in the correct category in the proper format
- [x] The description is one sentence and under 120 characters
- [x] I followed the current guideline not to append inline tags
- [x] The GitHub repository link works; the current list format does not use per-item star badges
- [x] The link works and points to the correct resource

## Why does this tool belong on the list?

agent-qa brings self-improving web and mobile regression tests into CI/CD through natural-language tests, CLI workflows, persistent memory, and self-healing execution. The added description is 111 characters, ends with a period, and preserves alphabetical placement.

Project disclosure: this submission is for agent-qa itself.
