### PR TITLE
Add Corelayer to AI Incident Response and Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ AI systems that detect, investigate, and remediate production incidents.
 - [AWS DevOps Agent](https://aws.amazon.com/devops-agent/) - AWS frontier agent, generally available since March 2026, that works as an always-on operations teammate resolving and proactively preventing incidents across AWS, multicloud, and on-prem environments.
 - [BigPanda](https://www.bigpanda.io/) - AIOps platform for event correlation, automated root cause analysis, and intelligent incident management across hybrid environments.
 - [Blameless](https://www.blameless.com/) - SRE platform with AI-powered incident management, automated retrospectives, and reliability insights across distributed systems.
+- [Corelayer](https://www.corelayer.com/) - Agentic production support platform that proactively root-causes issues using its Production Context Engine, with flexible deployment options for sensitive environments.
 - [FireHydrant](https://firehydrant.com/) - Incident management platform with AI-powered retrospective generation, automated status pages, and runbook execution.
 - [Gemini Cloud Assist](https://cloud.google.com/products/gemini/cloud-assist) - Google Cloud's AI assistant for cloud operations with Investigations for root cause analysis, troubleshooting, and cost and reliability optimization across GCP resources.
 - [GitHub Agentic Workflows](https://github.github.io/gh-aw/) - Run AI agents in GitHub Actions for automated issue triage, CI failure analysis, and PR review.


### PR DESCRIPTION
## What does this PR add or change?

This PR adds Corelayer to the category, "AI Incident Response and Troubleshooting"

## Checklist

- [X] The link returns HTTP 200 and points to the tool's canonical homepage, repo, or docs — **no tracking parameters** (`?ref=`, `?utm_=`, etc.)
- [X] The tool is relevant to DevOps, SRE, or Platform Engineering **and has a clear AI/ML component**
- [X] The project has real adoption (for open source: meaningful stars, forks, or an active community — very early personal projects are closed until they gain traction)
- [X] The entry is placed in the correct category **in alphabetical order**
- [X] The format matches `- [Name](https://link) - Description that ends with a period.`
- [X] The description states what the tool does, not marketing copy
- [X] The tool is not already in the list (search the README first — duplicates fail CI)
- [X] I am not removing the trailing newline at the end of README.md

## Disclosure

- [ ] I am affiliated with this tool (author, employee, contributor) — *self-submissions are welcome when the project meets the quality bar; just tell us*
