### PR TITLE
Add YYLO to AI Agent Frameworks for Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ General-purpose AI agent frameworks with strong infrastructure and DevOps use ca
 - [smolagents](https://github.com/huggingface/smolagents) - Minimalist open-source AI agent library from Hugging Face where agents write and execute Python code directly with sandboxed execution.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) - Microsoft's SDK for integrating LLMs into applications with plugin architecture ideal for building infrastructure automation agents.
 - [Temporal](https://github.com/temporalio/temporal) - Durable execution platform for orchestrating long-running infrastructure workflows with built-in retry and failure handling.
+- [YYLO](https://github.com/yylo-dev/yylo) - CLI orchestrator for coding agents with typed validation, merge, and release-readiness boundaries, per-task Git worktrees, and a risk-based merge queue.
 - [DSPy](https://github.com/stanfordnlp/dspy) - Stanford framework for programming language models with automatic prompt optimization and weight tuning, ideal for building reliable DevOps AI pipelines.
 - [OpenClaw](https://github.com/openclaw/openclaw) - Open-source personal AI assistant with 50+ integrations across messaging platforms, self-extending agent skills, and fully local execution for privacy.
 - [Wren AI](https://github.com/Canner/WrenAI) - Open-source text-to-SQL AI agent that generates SQL queries from natural language for infrastructure analytics and reporting.


### PR DESCRIPTION
## What does this PR add or change?

- **YYLO** — https://github.com/yylo-dev/yylo → **AI Agent Frameworks for Infrastructure**

## Checklist

- [x] The link returns HTTP 200 and points to the tool's canonical homepage, repo, or docs — **no tracking parameters**
- [x] The tool is relevant to DevOps, SRE, or Platform Engineering **and has a clear AI/ML component** — it orchestrates LLM coding agents (Pi/Codex subagents) and enforces typed task, validation, merge, and release-readiness boundaries on the changes they produce: per-task isolated Git worktrees, a risk-based merge queue, and hash-linked receipts/manifests for every landed change (delivery-pipeline governance for AI-coded changes)
- [x] The project has real adoption — 57 GitHub stars, 6 forks, MIT-licensed, 8 months of daily development, npm package [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli) at ~563 downloads/month (latest 0.2.2), and already included in other curated lists via merged PRs (e.g. Piebald-AI/awesome-gemini-cli #116, kailiu42/awesome-coding-agents #44, acvnace/awesome-vibe-coding-resources #81)
- [x] The entry is placed in the correct category **in alphabetical order** — inserted after Temporal (the last alphabetical entry in the section); happy to re-file to *AI Coding Agents for Infrastructure* if that's a better home (Conductor and Sculptor are close siblings there)
- [x] The format matches `- [Name](https://link) - Description that ends with a period.`
- [x] The description states what the tool does, not marketing copy
- [x] The tool is not already in the list — searched the README first (zero prior matches)
- [x] I am not removing the trailing newline at the end of README.md — diff is +1/−0 and `git diff --check` is clean

## Validation

- Ran `npx awesome-lint` locally on the branch: no new findings vs. pristine `main` (the two `Postgres` spell warnings and the git-repository error reproduce identically on unmodified `main`, so they're pre-existing).
- Ran the venue's link-check target URL manually — `https://github.com/yylo-dev/yylo` returns HTTP 200.

## Disclosure

- [x] I am affiliated with this tool — I'm on the YYLO team (self-submission, disclosed up front per the guidelines). This PR was prepared with AI assistance, and every description phrase is quotable from the YYLO README.
